### PR TITLE
Update sharpsheet.js

### DIFF
--- a/src/sharpsheet.js
+++ b/src/sharpsheet.js
@@ -13,7 +13,7 @@ import ShelfPack from "@mapbox/shelf-pack";
 // });
 
 export default async function sharpsheet(input, _outputPath, options) {
-  const border = options.border || 1;
+  const border = options.border ?? 1;
   const sheetDimension = options.sheetDimension || 1024;
   const outputFormat = options.outputFormat || "png";
   const outputQuality = options.outputQuality || 100;


### PR DESCRIPTION
When border is 0 "options.border || 1" returns 1 because 0 is considered "falsy".  💖